### PR TITLE
Update ubuntu version in index.md

### DIFF
--- a/index.md
+++ b/index.md
@@ -52,6 +52,8 @@ various *NIX distributions. All binary packages are built using the
 | Ubuntu Yakkety Yak      | 16.10           | `xUbuntu_16.10` |
 | Ubuntu Zesty Zapus      | 17.04           | `xUbuntu_17.04` |
 | Ubuntu Artful Aardvark  | 17.10           | `xUbuntu_17.10` |
+| Ubuntu Bionic Beaver    | 18.04           | `xUbuntu_18.04` |
+| Ubuntu Cosmic Cuttlefish| 18.10           | `xUbuntu_18.10` |
 
 1. Create `/etc/apt/sources.list.d/jgeboski.list` with the following content:
 


### PR DESCRIPTION
I added the two latests versions of Ubuntu. 

You can notice that facebook-purple does not work for ubuntu 18.10

![image](https://user-images.githubusercontent.com/2221668/51084186-eaadd380-1725-11e9-9dbc-c84e02910bfc.png)
